### PR TITLE
Add clean end-to-end workflow notebook

### DIFF
--- a/End to End/Comprehensive_clean.ipynb
+++ b/End to End/Comprehensive_clean.ipynb
@@ -1,0 +1,113 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Comprehensive Clean Workflow\n",
+    "Brief overview referencing earlier notebooks such as `Comprehensive.ipynb` for validation and experimental checks."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "Import configuration and set random seeds and device."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import config\n",
+    "import random\n",
+    "import numpy as np\n",
+    "import torch\n",
+    "\n",
+    "np.random.seed(config.SEED)\n",
+    "torch.manual_seed(config.SEED)\n",
+    "random.seed(config.SEED)\n",
+    "\n",
+    "device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Data Generation\n",
+    "Generate training and test datasets. See earlier notebook `Data Generation/Initial Accuracy_Check.ipynb` for validation of data generation procedures."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "sys.path.append('../Data Generation')\n",
+    "from data_generation import generate_train, generate_test\n",
+    "\n",
+    "train_data = generate_train()\n",
+    "test_data = generate_test()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Model Training\n",
+    "Train BasketNet with differential approach. Prior training experiments are documented in `Neural Networks/Monte Carlo & Adjoint-Mode Greeks.ipynb`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from models import BasketNet, run_differential\n",
+    "\n",
+    "model = BasketNet().to(device)\n",
+    "run_differential(model, train_data, test_data, device=device)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Evaluation\n",
+    "Compute accuracy and pricing diagnostics. Additional evaluation experiments are available in `Neural Networks/NN + Delta and Vega.ipynb`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from evaluation import enhanced_stats, price_stats\n",
+    "\n",
+    "enhanced = enhanced_stats(model, test_data)\n",
+    "pricing = price_stats(model, test_data)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- Add `Comprehensive_clean.ipynb` outlining setup, data generation, model training, and evaluation steps
- Seed numpy, torch, and random with `config.SEED` and configure device
- Include references to previous notebooks for validation of each stage

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aba9eaddd88332b9bf4c04461489a3